### PR TITLE
Fix possible concurrent problems

### DIFF
--- a/src/main/java/it/polimi/se2019/network/client/Client.java
+++ b/src/main/java/it/polimi/se2019/network/client/Client.java
@@ -65,7 +65,7 @@ public class Client {
 	 */
 	// TODO this is garbage
 	@Deprecated
-	public void processMessage(Message message) {
+	public synchronized void processMessage(Message message) {
 		switch (message.getMessageType()) {
 			case NICKNAME:
 				if(message.getMessageSubtype() == MessageSubtype.REQUEST) {

--- a/src/main/java/it/polimi/se2019/network/server/ServerMessageHandler.java
+++ b/src/main/java/it/polimi/se2019/network/server/ServerMessageHandler.java
@@ -24,7 +24,7 @@ public class ServerMessageHandler {
 	 * Called when the client is registering himself on the server.
 	 * @param client the implementation of the client.
 	 */
-	public void onClientRegistration(ConnectionToClientInterface client) {
+	public synchronized void onClientRegistration(ConnectionToClientInterface client) {
 		clients.add(client);
 		Utils.logInfo("Registered new client.");
 		client.sendMessage(new Message(MessageType.NICKNAME, MessageSubtype.REQUEST));
@@ -34,7 +34,7 @@ public class ServerMessageHandler {
 	 * Called when receiving a message from the client.
 	 * @param message the message received.
 	 */
-	public void onMessageReceived(ConnectionToClientInterface client, Message message) {
+	public synchronized void onMessageReceived(ConnectionToClientInterface client, Message message) {
 		Utils.logInfo("The server received a message of type: " + message.getMessageType() + ", and subtype: " + message.getMessageSubtype() + ".");
 
 		// Don't process message of not registered clients.


### PR DESCRIPTION
Made all the interfacing methods between network classes and other classes synchronized:

`public synchronized void processMessage(Message message);`
Method in the client. I think this can be called multiple times if the client receives multiple messages simultaneously. If made synchronized messages will be processed sequentially.

`public synchronized void onClientRegistration(ConnectionToClientInterface client);`
`public synchronized void onMessageReceived(ConnectionToClientInterface client, Message message);`
These are the two methods in the server. These methods can be called concurrently since there may be multiple clients connected.  If made synchronized their execution will be sequential.


Tried to run the main of the server and of multiple clients and everything seems to work as usual.